### PR TITLE
Parse tags from markdown import

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "date-fns": "^2.29.3",
     "jsdom": "^20.0.3",
     "lodash-es": "^4.17.21",
+    "mdast-util-find-and-replace": "^2.2.2",
     "mdast-util-gfm-autolink-literal": "^1.0.2",
     "mdast-util-to-string": "^3.1.0",
     "micromark-extension-gfm-autolink-literal": "^1.0.3",

--- a/src/convertors/markdown/markdown-convertor.ts
+++ b/src/convertors/markdown/markdown-convertor.ts
@@ -2,6 +2,7 @@ import {markdownToHtml} from 'helpers/markdown'
 import {toDailyNoteId} from 'helpers/to-id'
 import {validateNotes} from 'helpers/validate'
 
+import {dailyDateFromFilename, toMarkdownId} from './markdown-helpers'
 import {
   ConvertedNote,
   ConvertOptions,
@@ -9,7 +10,6 @@ import {
   ConvertResponse,
   REFLECT_HOSTNAME,
 } from '../../types'
-import {dailyDateFromFilename, toMarkdownId} from './markdown-helpers'
 
 export class MarkdownConvertor implements Convertor {
   graphId: string

--- a/src/convertors/markdown/markdown-convertor.ts
+++ b/src/convertors/markdown/markdown-convertor.ts
@@ -2,7 +2,6 @@ import {markdownToHtml} from 'helpers/markdown'
 import {toDailyNoteId} from 'helpers/to-id'
 import {validateNotes} from 'helpers/validate'
 
-import {dailyDateFromFilename, toMarkdownId} from './markdown-helpers'
 import {
   ConvertedNote,
   ConvertOptions,
@@ -10,6 +9,7 @@ import {
   ConvertResponse,
   REFLECT_HOSTNAME,
 } from '../../types'
+import {dailyDateFromFilename, toMarkdownId} from './markdown-helpers'
 
 export class MarkdownConvertor implements Convertor {
   graphId: string

--- a/src/convertors/markdown/markdown-convertor.ts
+++ b/src/convertors/markdown/markdown-convertor.ts
@@ -33,7 +33,7 @@ export class MarkdownConvertor implements Convertor {
     filename,
     lastModified,
   }: ConvertOptions & {filename: string}): ConvertResponse {
-    const {html, subject, backlinks} = markdownToHtml(data, {
+    const {html, subject, backlinks, tags} = markdownToHtml(data, {
       graphId: this.graphId,
       linkHost: this.linkHost,
     })
@@ -49,6 +49,7 @@ export class MarkdownConvertor implements Convertor {
       subject,
       dailyAt: dailyDate?.getTime(),
       backlinks,
+      tags,
       updatedAt: lastModified,
     }
 

--- a/src/convertors/markdown/markdown-helpers.ts
+++ b/src/convertors/markdown/markdown-helpers.ts
@@ -1,5 +1,4 @@
-import {isValid, parse} from 'date-fns'
-import {kebabCase} from 'lodash-es'
+import {parse, isValid} from 'date-fns'
 
 import {stripFileExtension} from 'helpers/path'
 
@@ -15,5 +14,5 @@ export const dailyDateFromFilename = (filename: string): Date | undefined => {
 }
 
 export const toMarkdownId = (filename: string) => {
-  return kebabCase(`md-${filename}`)
+  return `md-${filename}`
 }

--- a/src/convertors/markdown/markdown-helpers.ts
+++ b/src/convertors/markdown/markdown-helpers.ts
@@ -1,4 +1,5 @@
-import {parse, isValid} from 'date-fns'
+import {isValid, parse} from 'date-fns'
+import {kebabCase} from 'lodash-es'
 
 import {stripFileExtension} from 'helpers/path'
 
@@ -14,5 +15,5 @@ export const dailyDateFromFilename = (filename: string): Date | undefined => {
 }
 
 export const toMarkdownId = (filename: string) => {
-  return `md-${filename}`
+  return kebabCase(`md-${filename}`)
 }

--- a/src/helpers/markdown/markdown.ts
+++ b/src/helpers/markdown/markdown.ts
@@ -9,9 +9,10 @@ import {unified} from 'unified'
 import {buildBacklinkUrl} from 'helpers/backlink'
 import {toNoteId} from 'helpers/to-id'
 
+import {Backlink} from '../../types'
 import {hydrateBacklinks} from './plugins/hydrate-backlink-note-ids'
 import {hydrateSubject} from './plugins/hydrate-subject'
-import {Backlink} from '../../types'
+import {parseTags} from './plugins/parse-tags'
 
 export const markdownToHtml = (
   content: string,
@@ -43,6 +44,7 @@ export const markdownToHtml = (
         return [pageResolver(pageName)]
       },
     })
+    .use(parseTags, {graphId, linkHost})
     .use(hydrateSubject)
     .use(pipeToRehype)
     .use(hydrateBacklinks, {graphId, linkHost})
@@ -53,5 +55,6 @@ export const markdownToHtml = (
     html: processor.toString(),
     subject: processor.data.subject as string | undefined,
     backlinks: processor.data.backlinks as Backlink[],
+    tags: processor.data.tags as string[],
   }
 }

--- a/src/helpers/markdown/markdown.ts
+++ b/src/helpers/markdown/markdown.ts
@@ -9,10 +9,10 @@ import {unified} from 'unified'
 import {buildBacklinkUrl} from 'helpers/backlink'
 import {toNoteId} from 'helpers/to-id'
 
-import {Backlink} from '../../types'
 import {hydrateBacklinks} from './plugins/hydrate-backlink-note-ids'
 import {hydrateSubject} from './plugins/hydrate-subject'
 import {parseTags} from './plugins/parse-tags'
+import {type Backlink} from '../../types'
 
 export const markdownToHtml = (
   content: string,

--- a/src/helpers/markdown/plugins/parse-tags.ts
+++ b/src/helpers/markdown/plugins/parse-tags.ts
@@ -1,0 +1,39 @@
+import {type Root, type StaticPhrasingContent} from 'mdast'
+import {findAndReplace, type ReplaceFunction} from 'mdast-util-find-and-replace'
+import {Plugin} from 'unified'
+
+import {buildTagUrl} from '../../tag'
+
+type ParseTagOptions = {
+  graphId: string
+  linkHost: string
+}
+
+// Don't match any URL reserved character https://en.wikipedia.org/wiki/URL_encoding
+const TAG_REGEX = /#([^\s!#$&'"*+,\\/:;=?@%|(){}[\]<>]+)/giu
+
+export const parseTags: Plugin<[ParseTagOptions], Root> = (options: ParseTagOptions) => {
+  return (tree, file) => {
+    const tags = new Set<string>()
+
+    const replaceTag: ReplaceFunction = (value: string) => {
+      value = value.toLocaleLowerCase()
+      const tag = value.startsWith('#') ? value.slice(1) : null
+
+      if (!tag) return false
+
+      tags.add(tag)
+
+      const url = buildTagUrl({graphId: options.graphId, linkHost: options.linkHost, tag})
+
+      const node: StaticPhrasingContent = {type: 'text', value}
+
+      return {type: 'link', title: null, url, children: [node]}
+    }
+
+    findAndReplace(tree, [[TAG_REGEX, replaceTag]], {ignore: ['link', 'linkReference']})
+
+    const data = {tags: Array.from(tags)}
+    file.data = {...file.data, ...data}
+  }
+}

--- a/src/helpers/tag.ts
+++ b/src/helpers/tag.ts
@@ -1,5 +1,3 @@
-import 'urlpattern-polyfill'
-
 export const buildTagUrl = ({
   linkHost,
   graphId,

--- a/src/helpers/tag.ts
+++ b/src/helpers/tag.ts
@@ -1,0 +1,13 @@
+import 'urlpattern-polyfill'
+
+export const buildTagUrl = ({
+  linkHost,
+  graphId,
+  tag,
+}: {
+  linkHost: string
+  graphId: string
+  tag: string
+}) => {
+  return `https://${linkHost}/g/${graphId}/tag/${tag}`
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,8 @@ export interface ConvertedNote {
   subject?: string
   // A list of note ids that are references from inside this note
   backlinks?: Backlink[]
+  // A list of tag strings
+  tags?: string[]
   // The date the note was created
   createdAt?: number
   // The date the note was updated

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,6 +2428,16 @@ mdast-util-find-and-replace@^2.0.0:
     unist-util-is "^5.0.0"
     unist-util-visit-parents "^5.0.0"
 
+mdast-util-find-and-replace@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz#cc2b774f7f3630da4bd592f61966fecade8b99b1"
+  integrity sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    escape-string-regexp "^5.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.0.0"
+
 mdast-util-from-markdown@^0.8.5:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"


### PR DESCRIPTION
Parse hash tags from the markdown and returns them as an array of strings. 

See the test for all edge cases I can think of when parsing tags. 