### PR TITLE
Make children optional

### DIFF
--- a/src/convertors/logseq/logseq-convertor.ts
+++ b/src/convertors/logseq/logseq-convertor.ts
@@ -51,7 +51,7 @@ export class LogseqConvertor extends Convertor {
     const subject = note['page-name']
 
     // Get all the HTML and backlinks for the current note
-    const {html, backlinks} = this.parseBlocks(children)
+    const {html, backlinks} = this.parseBlocks(children ?? [])
     // Update the backlinks with the note ids from the page name to id map
     const updatedBacklinks = backlinks.map((b) => ({
       label: b.label,
@@ -121,7 +121,7 @@ export class LogseqConvertor extends Convertor {
     })
 
     // If the block has children then we need to get the html for the children
-    if (block.children.length) {
+    if (block.children?.length) {
       const {html: childHtml, backlinks: childBacklinks} = this.parseBlocks(
         block.children,
       )

--- a/src/convertors/logseq/schema.ts
+++ b/src/convertors/logseq/schema.ts
@@ -10,18 +10,18 @@ const baseBlockSchema = z.object({
 })
 
 type BlockSchema = z.infer<typeof baseBlockSchema> & {
-  children: BlockSchema[]
+  children?: BlockSchema[]
 }
 
 const blockSchema: z.ZodType<BlockSchema> = baseBlockSchema.extend({
-  children: z.lazy(() => blockSchema.array()),
+  children: z.lazy(() => blockSchema.array()).optional(),
 })
 
 const noteSchema = z.object({
   'page-name': z.string(),
   id: z.string(),
   properties: propertiesSchema.nullable(),
-  children: z.array(blockSchema),
+  children: z.array(blockSchema).optional(),
 })
 
 export const exportSchema = z.object({

--- a/src/convertors/logseq/types.ts
+++ b/src/convertors/logseq/types.ts
@@ -9,7 +9,7 @@ export interface LogseqNote {
   'page-name': string
   id: string
   properties: LogseqProperties | null
-  children: LogseqBlock[]
+  children?: LogseqBlock[]
 }
 
 export type LogseqProperties = Record<string, string | number | Array<string>>
@@ -21,11 +21,11 @@ export interface LogseqNoteBlock {
   content: string
   properties: LogseqProperties | null
   id: string
-  children: LogseqBlock[]
+  children?: LogseqBlock[]
 }
 
 export interface LogseqWhiteboardBlock {
-  children: LogseqBlock[]
+  children?: LogseqBlock[]
 }
 
 export class LogseqConversionError extends ConversionError {


### PR DESCRIPTION
The user David Dobbs had a failing LogSeq import.

He wouldn't share his whole JSON with me, so he jumped on a call and I extracted the note which was failing for him by running a Ruby script. (No Node on his machine).

Then I tried importing this node on my own machine and I learned that this node was entirely missing the children key for some of the blocks.

![CleanShot 2023-11-03 at 15 30 38@2x](https://github.com/team-reflect/reflect-import/assets/50943/944dbdb6-5a09-4dd1-aa35-1fbb4a7c6d94)


I'm assuming this is coming from an older version of LogSeq or something like that, but I think it would be good if we extend our support to all versions and make sure as many files can be imported as possible.