### PR TITLE
Ignore backlinks to daily notes

### DIFF
--- a/src/convertors/logseq/__snapshots__/logseq-convertor.test.ts.snap
+++ b/src/convertors/logseq/__snapshots__/logseq-convertor.test.ts.snap
@@ -60,16 +60,7 @@ exports[`LogseqConvertor > parses example 1`] = `
     "subject": "Contents",
   },
   {
-    "backlinks": [
-      {
-        "id": "02052023",
-        "label": "May 2nd, 2023",
-      },
-      {
-        "id": "04052023",
-        "label": "May 4th, 2023",
-      },
-    ],
+    "backlinks": [],
     "dailyAt": 1683072000000,
     "html": "<h1>May 3rd, 2023</h1><ul><li><p>This is a test graph</p></li><li><p><a class=\\"backlink new\\" href=\\"https://reflect.app/g/123/02052023\\">May 2nd, 2023</a></p><ul><li><p>This is some notes for yesterday</p></li></ul></li><li><p><a class=\\"backlink new\\" href=\\"https://reflect.app/g/123/04052023\\">May 4th, 2023</a></p><ul><li><p>This is some notes for tomorrow</p></li></ul></li></ul>",
     "id": "03052023",

--- a/src/convertors/logseq/logseq-convertor.test.ts
+++ b/src/convertors/logseq/logseq-convertor.test.ts
@@ -14,6 +14,7 @@ describe('LogseqConvertor', () => {
 
     expect(notes).toMatchSnapshot()
   })
+
   it('parses properties example', async () => {
     const convertor = new LogseqConvertor({graphId: '123'})
     const {notes} = await convertor.convert({
@@ -22,12 +23,14 @@ describe('LogseqConvertor', () => {
 
     expect(notes).toMatchSnapshot()
   })
+
   it('parses TODO example', async () => {
     const convertor = new LogseqConvertor({graphId: '123'})
     const {notes} = await convertor.convert({data: JSON.stringify(exampleTodoExport)})
 
     expect(notes).toMatchSnapshot()
   })
+
   it('handles and ignores whiteboard pages', async () => {
     const convertor = new LogseqConvertor({graphId: '123'})
     const {notes} = await convertor.convert({
@@ -36,10 +39,25 @@ describe('LogseqConvertor', () => {
 
     expect(notes).toMatchSnapshot()
   })
+
   it('exception for Org example', () => {
     const convertor = new LogseqConvertor({graphId: '123'})
     expect(
       async () => await convertor.convert({data: JSON.stringify(exampleOrgExport)}),
     ).rejects.toThrowError()
+  })
+
+  it('does not include daily backlinks', async () => {
+    const data = {
+      ...exampleExport,
+      blocks: exampleExport.blocks.filter((b) => b['page-name'] === 'May 3rd, 2023'),
+    }
+
+    const convertor = new LogseqConvertor({graphId: '123'})
+    const {notes} = await convertor.convert({data: JSON.stringify(data)})
+    expect(notes.length).toBe(1)
+    const note = notes[0]
+
+    expect(note.backlinks).toEqual([])
   })
 })

--- a/src/convertors/logseq/logseq-convertor.ts
+++ b/src/convertors/logseq/logseq-convertor.ts
@@ -122,7 +122,7 @@ export class LogseqConvertor extends Convertor {
     })
 
     // Remove backlinks to daily notes. Reflect will automatically create the
-    // daily note when daily baclink is clicked. Also, Reflect importing logic
+    // daily note when daily backlink is clicked. Also, Reflect importing logic
     // doesn't recognize daily backlinks, so this would create regular note with
     // daily-like ID, which would break the UI.
     //

--- a/src/convertors/logseq/logseq-convertor.ts
+++ b/src/convertors/logseq/logseq-convertor.ts
@@ -9,6 +9,7 @@ import {exportSchema} from './schema'
 import {LogseqBlock, LogseqConversionError, LogseqExport, LogseqNote} from './types'
 import {Convertor} from '../../convertor'
 import {Backlink, ConvertedNote, ConvertOptions, ConvertResponse} from '../../types'
+import {isDailyNoteId} from 'helpers/to-id'
 
 export class LogseqConvertor extends Convertor {
   static accept = {'application/json': ['.json']}
@@ -119,6 +120,14 @@ export class LogseqConvertor extends Convertor {
       linkHost: this.linkHost,
       pageResolver: (pageName) => toLogseqId(this.noteIds[pageName], pageName),
     })
+
+    // Remove backlinks to daily notes. Reflect will automatically create the
+    // daily note when daily baclink is clicked. Also, Reflect importing logic
+    // doesn't recognize daily backlinks, so this would create regular note with
+    // daily-like ID, which would break the UI.
+    //
+    // See also: https://height.app/dWwdXWnlP/T-2442
+    backlinks = backlinks.filter((backlink) => !isDailyNoteId(backlink.id))
 
     // If the block has children then we need to get the html for the children
     if (block.children?.length) {

--- a/src/helpers/to-id.ts
+++ b/src/helpers/to-id.ts
@@ -12,3 +12,8 @@ export const toNoteId = (value: string) => {
 export const toDailyNoteId = (date: Date) => {
   return format(date, 'ddMMyyyy')
 }
+
+export const isDailyNoteId = (value: string) => {
+  const match = value.match(/^(\d{2})(\d{2})(\d{4})$/)
+  return !!match
+}

--- a/src/helpers/to-id.ts
+++ b/src/helpers/to-id.ts
@@ -14,6 +14,5 @@ export const toDailyNoteId = (date: Date) => {
 }
 
 export const isDailyNoteId = (value: string) => {
-  const match = value.match(/^(\d{2})(\d{2})(\d{4})$/)
-  return !!match
+  return (/^(\d{2})(\d{2})(\d{4})$/).test(value)
 }


### PR DESCRIPTION
Fixes https://height.app/dWwdXWnlP/T-2442

This fixes a serious problem that users saw who imported notes from LogSeq.

Sometimes they imported notes which had backlinks to daily notes which didn't exist.

And when we imported a backlink to another daily node, we would always import it as a regular note. So we basically created a regular note with id that looks just like a daily note.

And then the whole UI would just go bonkers because there should not be a regular note with id that looks like a daily note.

Perhaps the proper solution would be to derive daily-ness of a note from the ID, not from the dailyAt flag.