### PR TITLE
remove prefix from markdown slugify, normalize name with backlinks to avoid dups

### DIFF
--- a/src/convertors/markdown/markdown-convertor.test.ts
+++ b/src/convertors/markdown/markdown-convertor.test.ts
@@ -39,6 +39,29 @@ describe('id', () => {
     })
     const [{id}] = notes
 
-    expect(id).toEqual('alexmaccaw')
+    expect(id).toEqual('md-alex-maccaw')
+  })
+})
+
+describe('backlinks', () => {
+  it('creates backlinks', async () => {
+    const data = `
+# Alex MacCaw
+
+- line [[With Backlink]]
+`
+    const convertor = new MarkdownConvertor({graphId: '123'})
+    const {notes} = await convertor.convert({
+      data,
+      filename: 'Alex MacCaw.md',
+    })
+    const [{backlinks}] = notes
+
+    expect(backlinks).toMatchObject([
+      {
+        id: 'md-with-backlink',
+        label: 'With Backlink',
+      },
+    ])
   })
 })

--- a/src/convertors/markdown/markdown-convertor.test.ts
+++ b/src/convertors/markdown/markdown-convertor.test.ts
@@ -33,9 +33,12 @@ describe('isDaily', () => {
 describe('id', () => {
   it('slugifies filename', async () => {
     const convertor = new MarkdownConvertor({graphId: '123'})
-    const {notes} = await convertor.convert({data: '# foo', filename: 'foo wem.md'})
+    const {notes} = await convertor.convert({
+      data: '# Alex MacCaw',
+      filename: 'Alex MacCaw.md',
+    })
     const [{id}] = notes
 
-    expect(id).toEqual('md-foo-wem')
+    expect(id).toEqual('alexmaccaw')
   })
 })

--- a/src/convertors/markdown/markdown-helpers.ts
+++ b/src/convertors/markdown/markdown-helpers.ts
@@ -17,7 +17,7 @@ export const dailyDateFromFilename = (filename: string): Date | undefined => {
 export const filenameToId = (filename: string) => {
   const basename = stripFileExtension(filename)
 
-  return `md-${slugify(basename)}`
+  return `${slugify(basename, {lowercase: true, decamelize: false, separator: ''})}`
 }
 
 export const filenameToSubject = (filename: string) => {

--- a/src/convertors/markdown/markdown-helpers.ts
+++ b/src/convertors/markdown/markdown-helpers.ts
@@ -1,6 +1,6 @@
-import slugify from '@sindresorhus/slugify'
 import {parse, isValid} from 'date-fns'
 
+import {toMarkdownNoteId} from 'helpers/markdown/markdown-helpers'
 import {stripFileExtension} from 'helpers/path'
 
 export const dailyDateFromFilename = (filename: string): Date | undefined => {
@@ -16,8 +16,7 @@ export const dailyDateFromFilename = (filename: string): Date | undefined => {
 
 export const filenameToId = (filename: string) => {
   const basename = stripFileExtension(filename)
-
-  return `${slugify(basename, {lowercase: true, decamelize: false, separator: ''})}`
+  return toMarkdownNoteId(basename)
 }
 
 export const filenameToSubject = (filename: string) => {

--- a/src/helpers/markdown/markdown-helpers.ts
+++ b/src/helpers/markdown/markdown-helpers.ts
@@ -1,0 +1,8 @@
+import slugify from '@sindresorhus/slugify'
+
+export function toMarkdownNoteId(value: string) {
+  const prefix = value.startsWith('md-') ? '' : 'md-'
+  const slug = slugify(value, {lowercase: true, decamelize: false, separator: '-'})
+
+  return `${prefix}${slug}`
+}

--- a/src/helpers/markdown/markdown.test.ts
+++ b/src/helpers/markdown/markdown.test.ts
@@ -25,7 +25,7 @@ This is a test
       <ul>
       <li>[ ] This is a task</li>
       <li>[x] This is a completed task</li>
-      <li>[ ] This is a task with a <a class=\\"backlink new\\" href=\\"https://reflect.app/g/testgraph/link\\">link</a></li>
+      <li>[ ] This is a task with a <a class=\\"backlink new\\" href=\\"https://reflect.app/g/testgraph/md-link\\">link</a></li>
       </ul>"
     `)
   })
@@ -60,11 +60,11 @@ This is a test
 
     expect(backlinks).toEqual([
       {
-        id: 'mybacklink',
+        id: 'md-my-backlink',
         label: 'my backlink',
       },
       {
-        id: 'anotherbacklink',
+        id: 'md-another-backlink',
         label: 'another backlink',
       },
     ])
@@ -72,8 +72,8 @@ This is a test
     // Backlinks should be converted to links
     expect(html).toMatchInlineSnapshot(`
       "<h1>Hello World</h1>
-      <p><a class=\\"backlink new\\" href=\\"https://reflect.app/g/testgraph/mybacklink\\">my backlink</a>
-      <a class=\\"backlink new\\" href=\\"https://reflect.app/g/testgraph/anotherbacklink\\">another backlink</a></p>"
+      <p><a class=\\"backlink new\\" href=\\"https://reflect.app/g/testgraph/md-my-backlink\\">my backlink</a>
+      <a class=\\"backlink new\\" href=\\"https://reflect.app/g/testgraph/md-another-backlink\\">another backlink</a></p>"
     `)
   })
 

--- a/src/helpers/markdown/markdown.ts
+++ b/src/helpers/markdown/markdown.ts
@@ -7,8 +7,8 @@ import wikiLinkPlugin from 'remark-wiki-link'
 import {unified} from 'unified'
 
 import {buildBacklinkUrl} from 'helpers/backlink'
-import {toNoteId} from 'helpers/to-id'
 
+import {toMarkdownNoteId} from './markdown-helpers'
 import {hydrateBacklinks} from './plugins/hydrate-backlink-note-ids'
 import {hydrateSubject} from './plugins/hydrate-subject'
 import {parseTags} from './plugins/parse-tags'
@@ -23,7 +23,12 @@ export const markdownToHtml = (
     pageResolver?: (pageName: string) => string
   },
 ) => {
-  const {constructsToDisable = [], graphId, linkHost, pageResolver = toNoteId} = options
+  const {
+    constructsToDisable = [],
+    graphId,
+    linkHost,
+    pageResolver = toMarkdownNoteId,
+  } = options
 
   const processor = unified()
     .data('micromarkExtensions', [


### PR DESCRIPTION
There’s currently a discrepancy between import note `ids`, which were [prefixed](https://github.com/team-reflect/reflect-import/blob/master/src/convertors/markdown/markdown-helpers.ts#L17) with `md` and slugified in a different way than [backlink ids](https://github.com/team-reflect/reflect-import/blob/master/src/helpers/to-id.ts#L4), ie a parsed note with the name `Alex MacCaw` will have a `noteId` of `md-alex-mac-caw`, and another note that references `[[Alex MacCaw]]` will have a generated backlink ID of `alexmaccaw`, which can cause duplicates upon iimport.

This normalizes them to the current backlink ID (both will show as `alexmaccaw`, which allows avoiding duplicates in the main repo + allows replacing backlink `html` in a way that links any imported backlinks to the appropriate DB note.
